### PR TITLE
raise error if given unknown type

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -201,6 +201,8 @@ def joyplot(data, column=None, by=None, grid=False,
             converted = [_remove_na(g) for g in data if _is_numeric(g)]
         labels = None
         sublabels = None
+    else:
+        raise TypeError("Unknown type for 'data': {!r}".format(type(data)))
 
     if ylabels is False:
         labels = None


### PR DESCRIPTION
currently you just get `UnboundLocalError: local variable 'converted' referenced before assignment` from line 208 if you pass, for example, `numpy.ndarray` (which btw could be used with `pd.DataFrame(data)`)