### PR TITLE
Workaround to fix #26 due to bug 11702 in matplotlib

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -448,6 +448,7 @@ def _joyplot(data,
             a.legend(loc=loc)
             # Bypass alpha values, in case
             for p in a.get_legend().get_patches():
+                p.set_facecolor(p.get_facecolor())
                 p.set_alpha(1.0)
             for l in a.get_legend().get_lines():
                 l.set_alpha(1.0)


### PR DESCRIPTION
Fix #26 by explicitly setting the facecolor of the legend patches.
This is a workaround to handle matplotlib/matplotlib#11702 

![image](https://user-images.githubusercontent.com/1311290/46631946-3f4f1a80-cb49-11e8-8461-0ec31f77badd.png)

