### PR TITLE
Handle groups with no values

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -250,8 +250,12 @@ def plot_density(ax, x_range, v, kind="kde", bw_method=None,
         return
 
     if kind == "kde":
-        gkde = gaussian_kde(v, bw_method=bw_method)
-        y = gkde.evaluate(x_range)
+        try:
+            gkde = gaussian_kde(v, bw_method=bw_method)
+            y = gkde.evaluate(x_range)
+        except ValueError:
+            # Handle cases where there is no data in a group.
+            y = np.zeros_like(x_range)
     elif kind == "counts":
         y, bin_edges = np.histogram(v, bins=bins, range=(min(x_range), max(x_range)))
         # np.histogram returns the edges of the bins.


### PR DESCRIPTION
```python
import pandas as pd
import numpy as np
import joypy

means = np.arange(5)
n = 100
y = np.random.normal(np.repeat(means, n), 1)
df = pd.DataFrame([np.repeat(means, n), y], index=['Group', 'Value']).T
df['MissingValue'] = np.where(df['Group']==2, np.nan, df['Value'])

joypy.joyplot(df, column='Value', by='Group')

```

![image](https://user-images.githubusercontent.com/3819320/64447704-ed55a280-d0d3-11e9-94e0-46fe3eb8af9a.png)

New behaviour, previously raised `ValueError`
```python
joypy.joyplot(df, column='MissingValue', by='Group')
````
![image](https://user-images.githubusercontent.com/3819320/64447713-f34b8380-d0d3-11e9-920f-7c03c5789d8b.png)

Note that a warning is already raised on line 222.
