### PR TITLE
Adding an option to input manually a list of colors for the different density plots

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -88,6 +88,7 @@ def joyplot(data, column=None, by=None, grid=False,
             x_range=None,
             title=None,
             colormap=None,
+            color=None,
             **kwds):
     """
     Draw joyplot of a DataFrame, or appropriately nested collection,
@@ -236,6 +237,7 @@ def joyplot(data, column=None, by=None, grid=False,
                     range_style=range_style, x_range=x_range,
                     title=title,
                     colormap=colormap,
+                    color=color,
                     **kwds)
 
 ###########################################


### PR DESCRIPTION
In the case of large number of labels, there are not enough colors for drawing all the density matrices (get an error: plt.rcParams['axes.prop_cycle'].by_key()['color'][j] list index out of range).
This change enables to manually input a list of colors to the JoyPy function, in the length of the labels (all(len(g) == len(color) for g in data)).