### PR TITLE
Adding an option to color the individual density plots

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -89,7 +89,6 @@ def joyplot(data, column=None, by=None, grid=False,
             title=None,
             colormap=None,
             color=None,
-            colored_groups=False,
             **kwds):
     """
     Draw joyplot of a DataFrame, or appropriately nested collection,
@@ -129,8 +128,6 @@ def joyplot(data, column=None, by=None, grid=False,
     hist : boolean, default False
     bins : integer, default 10
         Number of histogram bins to be used
-    colored_groups : boolean, default False
-        If True AND no subgroups, the groups themselves will be colored
     kwds : other plotting keyword arguments
         To be passed to hist/kde plot function
     """
@@ -241,7 +238,6 @@ def joyplot(data, column=None, by=None, grid=False,
                     title=title,
                     colormap=colormap,
                     color=color,
-                    colored_groups=colored_groups,
                     **kwds)
 
 ###########################################
@@ -342,7 +338,7 @@ def _joyplot(data,
              range_style='all', x_range=None, tails=0.2,
              title=None,
              legend=False, loc="upper right",
-             colormap=None, color=None, colored_groups=False,
+             colormap=None, color=None,
              **kwargs):
     """
     Internal method.
@@ -382,7 +378,7 @@ def _joyplot(data,
 
     def _get_color(i, num_axes, j, num_subgroups):
         if isinstance(color, list):
-            return color[j]
+            return color[j] if num_subgroups > 1 else color[i]
         elif color is not None:
             return color
         elif isinstance(colormap, list):
@@ -463,10 +459,7 @@ def _joyplot(data,
                     sublabel = sublabels[j]
 
                 element_zorder = group_zorder + j/(num_subgroups+1)
-                if ((len(group) == 1) & (colored_groups)):
-                    element_color = _get_color(i, num_axes, i, num_subgroups)
-                else:
-                    element_color = _get_color(i, num_axes, j, num_subgroups)
+                element_color = _get_color(i, num_axes, j, num_subgroups)
 
                 plot_density(a, x_range, subgroup,
                              fill=fill, linecolor=linecolor, label=sublabel,

--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -89,6 +89,7 @@ def joyplot(data, column=None, by=None, grid=False,
             title=None,
             colormap=None,
             color=None,
+            colored_groups=False,
             **kwds):
     """
     Draw joyplot of a DataFrame, or appropriately nested collection,
@@ -128,6 +129,8 @@ def joyplot(data, column=None, by=None, grid=False,
     hist : boolean, default False
     bins : integer, default 10
         Number of histogram bins to be used
+    colored_groups : boolean, default False
+        If True AND no subgroups, the groups themselves will be colored
     kwds : other plotting keyword arguments
         To be passed to hist/kde plot function
     """
@@ -238,6 +241,7 @@ def joyplot(data, column=None, by=None, grid=False,
                     title=title,
                     colormap=colormap,
                     color=color,
+                    colored_groups=colored_groups,
                     **kwds)
 
 ###########################################
@@ -338,7 +342,7 @@ def _joyplot(data,
              range_style='all', x_range=None, tails=0.2,
              title=None,
              legend=False, loc="upper right",
-             colormap=None, color=None,
+             colormap=None, color=None, colored_groups=False,
              **kwargs):
     """
     Internal method.
@@ -459,7 +463,10 @@ def _joyplot(data,
                     sublabel = sublabels[j]
 
                 element_zorder = group_zorder + j/(num_subgroups+1)
-                element_color = _get_color(i, num_axes, j, num_subgroups)
+                if ((len(group) == 1) & (colored_groups)):
+                    element_color = _get_color(i, num_axes, i, num_subgroups)
+                else:
+                    element_color = _get_color(i, num_axes, j, num_subgroups)
 
                 plot_density(a, x_range, subgroup,
                              fill=fill, linecolor=linecolor, label=sublabel,


### PR DESCRIPTION
Hi @sbebo, looks like there is no option to color the individual density plots in different axes (not subgroups). The colored_group flag enables coloring the individual density plots, **only of there are no subgroups**, based on the 'I' index instead of 'j' (which is always 0 if there are no subgroups, i.e. len(group) == 1):
```
if ((len(group) == 1) & (colored_groups)):
    element_color = _get_color(i, num_axes, i, num_subgroups)
else:
    element_color = _get_color(i, num_axes, j, num_subgroups)
```

Before:
![Figure_1](https://user-images.githubusercontent.com/39324784/74724478-4fc9d780-520a-11ea-9ca4-060129eaa74d.png)

After:
![Figure_2](https://user-images.githubusercontent.com/39324784/74724530-5eb08a00-520a-11ea-9856-256997ac5989.png)

Also here I put the flag explicitly in the joyplot arguments, but is can be passed also as kwds.
Thanks.