### PR TITLE
fix error in call to plot_density

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -497,7 +497,8 @@ def _joyplot(data,
                 plot_density(a, x_range, subgroup,
                              fill=fill, linecolor=linecolor, label=sublabel,
                              zorder=element_zorder, color=element_color,
-                             bins=bins, **kwargs)
+                             bins=bins, normalize=normalize, floc=floc,
+                             **kwargs)
 
         # Setup the current axis: transparency, labels, spines.
         col_name = None if labels is None else labels[i]


### PR DESCRIPTION
Only effected lognorm option, particular for real values of floc.