### PR TITLE
Fix ValueError when trying to plot with `hist=True` and color as list  of colors.

### DIFF
--- a/joypy/joyplot.py
+++ b/joypy/joyplot.py
@@ -464,7 +464,8 @@ def _joyplot(data,
 
         if hist:
             # matplotlib hist() already handles multiple subgroups in a histogram
-            a.hist(group, label=sublabels, bins=bins, color=color,
+            group_color = _get_color(i, num_axes, 0, num_subgroups)
+            a.hist(group, label=sublabels, bins=bins, color=group_color,
                    range=[min(global_x_range), max(global_x_range)],
                    edgecolor=linecolor, zorder=group_zorder, **kwargs)
         else:
@@ -582,4 +583,3 @@ def _joyplot(data,
     fig.tight_layout(h_pad=h_pad)
 
     return fig, _axes
-


### PR DESCRIPTION
Hi, I tried to plot a table with joypy with `hist=True` and "color" being a list of colors and got an error from matplotlib (v3.6.0).

## Error message:
"ValueError: The 'color' keyword argument must have one color per  dataset, but 1 datasets and 2 colors were provided"

## How to reproduce:
```
import numpy as np
import pandas as pd
import joypy

table = pd.DataFrame({'one':np.random.randn(1000), 'two': 
np.random.randn(1000) + 5})

joypy.joyplot(table, color=['skyblue', 'fuchsia'], hist=True)
```